### PR TITLE
Add errcheck linter

### DIFF
--- a/gometalinter.config
+++ b/gometalinter.config
@@ -1,6 +1,6 @@
 {
   "DisableAll": true,
-  "Enable": ["golint", "vet", "varcheck", "unparam"],
+  "Enable": ["golint", "vet", "varcheck", "unparam", "errcheck"],
   "Exclude": [
     "should have comment",
     "comment on exported",

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -141,8 +141,8 @@ func readPluginConfig(configFile string) (*PluginConfig, error) {
 }
 
 func validateConfig(config *PluginConfig) error {
-	required_keys := []string{"aws_access_key_id", "aws_secret_access_key", "region", "bucket", "folder"}
-	for _, key := range required_keys {
+	requiredKeys := []string{"aws_access_key_id", "aws_secret_access_key", "region", "bucket", "folder"}
+	for _, key := range requiredKeys {
 		if config.Options[key] == "" {
 			return fmt.Errorf("%s must exist in plugin configuration file", key)
 		}


### PR DESCRIPTION
This linter ensures that we check the error on functions that return an
error. This will help prevent bugs where we assume that a function such
as Chmod or Open is successful, but forget to check that no error is
returned.

In cases where we do intentionally want to ignore the error, we will now
need to assign it to an empty identifier, such as _ = os.Chmod().

Authored-by: Chris Hajas <chajas@pivotal.io>