### PR TITLE
Add support for using custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ options:
 
 **executablepath:**
 
-Absolute path to the plugin executable. For example, the path to the gpbackup S3 plugin is $GPHOME/bin/gpbackup_s3_plugin.
+Absolute path to the plugin executable. For example, the Greenplum Database installation location is $GPHOME/bin/gpbackup_s3_plugin.
 
 **options:**
 
@@ -35,7 +35,7 @@ Begins the S3 storage plugin options section.
 
 The AWS region.
 
-Note: This parameter will is be ignored if `endpoint` is specified.
+Note: This parameter will be ignored if `endpoint` is specified.
 
 **endpoint:**
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ To use the S3 plugin, you specify the location of the plugin and the AWS login a
 
 If you perform a backup operation with the gpbackup option --plugin-config, you must also specify the --plugin-config option when you restore the backup with gprestore.
 
+The S3 plugin supports both AWS and custom storage servers that implement the S3 interface.
+
 ## S3 Storage Plugin Configuration File Format
 The configuration file specifies the absolute path to the gpbackup_s3_plugin executable, AWS connection credentials, and S3 location.
 
@@ -14,6 +16,7 @@ The configuration file must be a valid YAML document in the following format:
 executablepath: <absolute-path-to-gpbackup_s3_plugin>
 options: 
   region: <aws-region>
+  endpoint: <s3-endpoint>
   aws_access_key_id: <aws-user-id>
   aws_secret_access_key: <aws-user-id-key>
   bucket: <s3-bucket>
@@ -22,7 +25,7 @@ options:
 
 **executablepath:**
 
-Absolute path to the plugin executable. For example, the Pivotal Greenplum Database installation location is $GPHOME/bin/gpbackup_s3_plugin.
+Absolute path to the plugin executable. For example, the path to the gpbackup S3 plugin is $GPHOME/bin/gpbackup_s3_plugin.
 
 **options:**
 
@@ -31,6 +34,14 @@ Begins the S3 storage plugin options section.
 **region:**
 
 The AWS region.
+
+Note: This parameter will is be ignored if `endpoint` is specified.
+
+**endpoint:**
+
+The endpoint to a server implementing the S3 interface.
+
+Note: This parameter should not be specified if using AWS.
 
 **aws_access_key_id:**
 
@@ -42,7 +53,7 @@ AWS S3 passcode for the S3 ID to access the S3 bucket location.
 
 **bucket:**
 
-The name of the S3 bucket in the AWS region. The bucket must exist.
+The name of the S3 bucket. The bucket must exist with the necessary permissions.
 
 **folder:**
 

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -14,7 +14,7 @@ func TestCluster(t *testing.T) {
 }
 
 var _ = Describe("s3_plugin tests", func() {
-	Context("GetS3Path", func() {
+	Describe("GetS3Path", func() {
 		It("", func() {
 			folder := "s3/Dir"
 			path := "/tmp/datadir/gpseg-1/backups/20180101/2018010101010101/backup_file"
@@ -23,7 +23,7 @@ var _ = Describe("s3_plugin tests", func() {
 			Expect(newPath).To(Equal(expectedPath))
 		})
 	})
-	Context("ValidateConfig", func() {
+	Describe("ValidateConfig", func() {
 		var pluginConfig *s3plugin.PluginConfig
 		BeforeEach(func() {
 			pluginConfig = &s3plugin.PluginConfig{

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -23,5 +23,66 @@ var _ = Describe("s3_plugin tests", func() {
 			Expect(newPath).To(Equal(expectedPath))
 		})
 	})
+	Context("ValidateConfig", func() {
+		var pluginConfig *s3plugin.PluginConfig
+		BeforeEach(func() {
+			pluginConfig = &s3plugin.PluginConfig{
+				ExecutablePath: "/tmp/location",
+				Options: map[string]string{
+					"aws_access_key_id":     "12345",
+					"aws_secret_access_key": "6789",
+					"bucket":                "bucket_name",
+					"folder":                "folder_name",
+					"region":                "region_name",
+					"endpoint":              "endpoint_name",
+				},
+			}
+		})
+		It("succeeds when all fields in config filled", func() {
+			err := s3plugin.ValidateConfig(pluginConfig)
+			Expect(err).To(BeNil())
+		})
+		It("succeeds when all fields except endpoint filled in config", func() {
+			delete(pluginConfig.Options, "endpoint")
+			err := s3plugin.ValidateConfig(pluginConfig)
+			Expect(err).To(BeNil())
+		})
+		It("succeeds when all fields except region filled in config", func() {
+			delete(pluginConfig.Options, "region")
+			err := s3plugin.ValidateConfig(pluginConfig)
+			Expect(err).To(BeNil())
+		})
+		It("sets region to unused when endpoint is used instead of region", func() {
+			delete(pluginConfig.Options, "region")
+			s3plugin.ValidateConfig(pluginConfig)
+			Expect(pluginConfig.Options["region"]).To(Equal("unused"))
+		})
+		It("returns error when neither region nor endpoint in config", func() {
+			delete(pluginConfig.Options, "region")
+			delete(pluginConfig.Options, "endpoint")
+			err := s3plugin.ValidateConfig(pluginConfig)
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns error when no aws_access_key_id in config", func() {
+			delete(pluginConfig.Options, "aws_access_key_id")
+			err := s3plugin.ValidateConfig(pluginConfig)
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns error when no aws_secret_access_key in config", func() {
+			delete(pluginConfig.Options, "aws_secret_access_key")
+			err := s3plugin.ValidateConfig(pluginConfig)
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns error when no bucket in config", func() {
+			delete(pluginConfig.Options, "bucket")
+			err := s3plugin.ValidateConfig(pluginConfig)
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns error when no folder in config", func() {
+			delete(pluginConfig.Options, "folder")
+			err := s3plugin.ValidateConfig(pluginConfig)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 
 })


### PR DESCRIPTION
The S3 plugin now supports specifying a custom endpoint instead of an
AWS region to backup/restore to/from a storage solution that implements
the S3 protocol.

Additionally, validate the configuration file prior to attempting to
connect to the S3 server.

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Amil Khanzada <akhanzada@pivotal.io>