### PR TITLE
Introduce backupDirectory and restoreDirectory

### DIFF
--- a/gpbackup_s3_plugin.go
+++ b/gpbackup_s3_plugin.go
@@ -47,8 +47,18 @@ func main() {
 			Before: buildBeforeFunc(2),
 		},
 		{
+			Name:   "backup_directory",
+			Action: s3plugin.BackupDirectory,
+			Before: buildBeforeFunc(2),
+		},
+		{
 			Name:   "restore_file",
 			Action: s3plugin.RestoreFile,
+			Before: buildBeforeFunc(2),
+		},
+		{
+			Name:   "restore_directory",
+			Action: s3plugin.RestoreDirectory,
 			Before: buildBeforeFunc(2),
 		},
 		{

--- a/gpbackup_s3_plugin.go
+++ b/gpbackup_s3_plugin.go
@@ -18,7 +18,8 @@ func main() {
 	}
 	app.Version = s3plugin.Version
 	app.Usage = ""
-	app.UsageText = "Not supported as a standalone utility.  This plugin must be used in conjunction with gpbackup and gprestore."
+	app.UsageText = "Not supported as a standalone utility. " +
+		"This plugin must be used in conjunction with gpbackup and gprestore."
 
 	app.Commands = []cli.Command{
 		{
@@ -50,6 +51,7 @@ func main() {
 			Name:   "backup_directory",
 			Action: s3plugin.BackupDirectory,
 			Before: buildBeforeFunc(2),
+			Hidden: true,
 		},
 		{
 			Name:   "restore_file",
@@ -60,6 +62,7 @@ func main() {
 			Name:   "restore_directory",
 			Action: s3plugin.RestoreDirectory,
 			Before: buildBeforeFunc(2),
+			Hidden: true,
 		},
 		{
 			Name:   "backup_data",

--- a/gpbackup_s3_plugin.go
+++ b/gpbackup_s3_plugin.go
@@ -54,6 +54,12 @@ func main() {
 			Hidden: true,
 		},
 		{
+			Name:   "backup_directory_parallel",
+			Action: s3plugin.BackupDirectoryParallel,
+			Before: buildBeforeFunc(2),
+			Hidden: true,
+		},
+		{
 			Name:   "restore_file",
 			Action: s3plugin.RestoreFile,
 			Before: buildBeforeFunc(2),
@@ -61,6 +67,12 @@ func main() {
 		{
 			Name:   "restore_directory",
 			Action: s3plugin.RestoreDirectory,
+			Before: buildBeforeFunc(2),
+			Hidden: true,
+		},
+		{
+			Name:   "restore_directory_parallel",
+			Action: s3plugin.RestoreDirectoryParallel,
 			Before: buildBeforeFunc(2),
 			Hidden: true,
 		},

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -106,6 +106,54 @@ func BackupFile(c *cli.Context) error {
 	return err
 }
 
+func isDirectory(path string) bool {
+	fd, err := os.Stat(path)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(2)
+	}
+	switch mode := fd.Mode(); {
+	case mode.IsDir():
+		return true
+	case mode.IsRegular():
+		return false
+	}
+	return false
+}
+
+func BackupDirectory(c *cli.Context) error {
+	gplog.InitializeLogging("gpbackup", "")
+	config, sess, err := readConfigAndStartSession(c)
+	if err != nil {
+		return err
+	}
+	dirName := c.Args().Get(1)
+	dirKey := GetS3Path(config.Options["folder"], dirName)
+	fmt.Printf("dirKey = %s\n", dirKey)
+	fileList := make([]string, 0)
+	filepath.Walk(dirName, func(path string, f os.FileInfo, err error) error {
+		if isDirectory(path) {
+			// Do nothing
+			return nil
+		} else {
+			fileList = append(fileList, path)
+			return nil
+		}
+	})
+	for _, fileName := range fileList {
+		file, err := os.Open(fileName)
+		if err != nil {
+			return err
+		}
+		totalBytes, err := uploadFile(sess, config.Options["bucket"], fileName, file)
+		if err == nil {
+			gplog.Verbose("Uploaded %d bytes for %s", totalBytes, fileName)
+		}
+		_ = file.Close()
+	}
+	return err
+}
+
 func RestoreFile(c *cli.Context) error {
 	gplog.InitializeLogging("gprestore", "")
 	config, sess, err := readConfigAndStartSession(c)
@@ -128,6 +176,47 @@ func RestoreFile(c *cli.Context) error {
 	} else {
 		gplog.FatalOnError(err)
 		_ = os.Remove(fileName)
+	}
+	return err
+}
+
+func RestoreDirectory(c *cli.Context) error {
+	gplog.InitializeLogging("gprestore", "")
+	config, sess, err := readConfigAndStartSession(c)
+	if err != nil {
+		return err
+	}
+	dirName := c.Args().Get(1)
+	bucket := config.Options["bucket"]
+	dirKey := GetS3Path(config.Options["folder"], dirName)
+	_ = os.MkdirAll(dirName, 0775)
+	fmt.Printf("dirKey = %s\n", dirKey)
+	client := s3.New(sess)
+	params := &s3.ListObjectsV2Input{Bucket: &bucket, Prefix: &dirKey}
+	bucketObjectsList, _ := client.ListObjectsV2(params)
+
+	for _, key := range bucketObjectsList.Contents {
+		var filename string
+		fmt.Printf("file %s = %d bytes\n", *key.Key, *key.Size)
+		if strings.HasSuffix(*key.Key, "/") {
+			// Got a directory
+			continue
+		}
+		if strings.Contains(*key.Key, "/") {
+			// split
+			s3FileFullPathList := strings.Split(*key.Key, "/")
+			filename = s3FileFullPathList[len(s3FileFullPathList)-1]
+		}
+		filePath := dirName + filename
+		file, err := os.Create(filePath)
+		if err != nil {
+			return err
+		}
+		_, err = downloadFile(sess, config.Options["bucket"], *key.Key, file)
+		if err != nil {
+			_ = os.Remove(filename)
+		}
+		_ = file.Close()
 	}
 	return err
 }


### PR DESCRIPTION
The performance testing job for S3 would backup and restore 10-50GB of data using parallel and serial versions of directory API.

Examples:
```
/usr/local/gpdb/bin/gpbackup_s3_plugin restore_directory ~/s3config.yaml backups/20200131/20200131144745

cat ~/gpAdminLogs/gprestore_20200316.log
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-Restore Directory 'backups/20200131/20200131144745' from S3
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-S3 Location = s3://gpbackup-s3-plugin-test/backups/backups/20200131/20200131144745
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-File 'gpbackup_0_20200131144745_2218753.gz' = 2456698614 bytes
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-File 'gpbackup_1_20200131144745_2218753.gz' = 2456571947 bytes
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-File 'gpbackup_20200131144745_config.yaml' = 716 bytes
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-File 'gpbackup_20200131144745_metadata.sql' = 1331966 bytes
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-File 'gpbackup_20200131144745_plugin_config.yaml' = 319 bytes
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-File 'gpbackup_20200131144745_report' = 1708 bytes
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-File 'gpbackup_20200131144745_toc.yaml' = 1401652 bytes
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-Downloaded 319 bytes for file gpbackup_20200131144745_plugin_config.yaml
20200316:16:27:53 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-Downloaded 716 bytes for file gpbackup_20200131144745_config.yaml
20200316:16:27:54 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-Downloaded 1708 bytes for file gpbackup_20200131144745_report
20200316:16:27:54 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-Downloaded 1331966 bytes for file gpbackup_20200131144745_metadata.sql
20200316:16:27:54 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-Downloaded 1401652 bytes for file gpbackup_20200131144745_toc.yaml
20200316:16:30:59 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-Downloaded 2456571947 bytes for file gpbackup_1_20200131144745_2218753.gz
20200316:16:31:02 gprestore:ljain:Lavs-MacBook-Pro.local:010345-[DEBUG]:-Downloaded 2456698614 bytes for file gpbackup_0_20200131144745_2218753.gz
```

```
/usr/local/gpdb/bin/gpbackup_s3_plugin backup_directory ~/_s3config.yaml backups/20200316/20200316094746

20200316:16:25:41 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-Backup Directory 'backups/20200316/20200316094746' to S3
20200316:16:25:41 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-S3 Location = s3://gpbackup-s3-plugin-test/backups/backups/20200316/20200316094746
20200316:16:25:41 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-File 'gpbackup_20200316094745_config.yaml' = 638 bytes
20200316:16:25:41 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-File 'gpbackup_20200316094745_metadata.sql' = 3904 bytes
20200316:16:25:41 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-File 'gpbackup_20200316094745_plugin_config.yaml' = 304 bytes
20200316:16:25:41 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-File 'gpbackup_20200316094745_report' = 1835 bytes
20200316:16:25:41 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-File 'gpbackup_20200316094745_toc.yaml' = 4366 bytes
20200316:16:25:42 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-Uploaded 304 bytes for gpbackup_20200316094745_plugin_config.yaml
20200316:16:25:42 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-Uploaded 3904 bytes for gpbackup_20200316094745_metadata.sql
20200316:16:25:42 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-Uploaded 4366 bytes for gpbackup_20200316094745_toc.yaml
20200316:16:25:42 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-Uploaded 1835 bytes for gpbackup_20200316094745_report
20200316:16:25:42 gpbackup:ljain:Lavs-MacBook-Pro.local:010336-[DEBUG]:-Uploaded 638 bytes for gpbackup_20200316094745_config.yaml
```