### PR TITLE
Use smaller chunk size during uploads

### DIFF
--- a/s3plugin/restore.go
+++ b/s3plugin/restore.go
@@ -224,7 +224,6 @@ func RestoreData(c *cli.Context) error {
 */
 const DownloadChunkSize = int64(Mebibyte) * 8
 const DownloadChunkIncrement = int64(Mebibyte) * 1
-const Concurrency = 6
 
 type chunk struct {
 	chunkIndex int

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -24,6 +24,7 @@ var Version string
 
 const apiVersion = "0.4.0"
 const Mebibyte = 1024 * 1024
+const Concurrency = 6
 
 type Scope string
 


### PR DESCRIPTION
* Change upload concurrency to 6.
* The s3-plugin-performance job shows an improvement of around 50% for uploads
