### PR TITLE
Fix regression in S3 plugin SetupPluginForBackup (metadata only)

### DIFF
--- a/s3plugin/backup.go
+++ b/s3plugin/backup.go
@@ -27,9 +27,10 @@ func SetupPluginForBackup(c *cli.Context) error {
 	}
 	localBackupDir := c.Args().Get(1)
 	_, timestamp := filepath.Split(localBackupDir)
-	testFilePath := fmt.Sprintf("%s/gpbackup_%s_report", localBackupDir, timestamp)
+	testFileName := fmt.Sprintf("gpbackup_%s_report", timestamp)
+	testFilePath := fmt.Sprintf("%s/%s", localBackupDir, testFileName)
 	fileKey := GetS3Path(config.Options["folder"], testFilePath)
-	file, err := os.Create(testFilePath) // dummy empty reader for probe
+	file, err := os.Create("/tmp/" + testFileName) // dummy empty reader for probe
 	defer func() {
 		_ = file.Close()
 	}()


### PR DESCRIPTION
When executed for metadata only, the call fails on the segments because the backup data directories do not exist. This behavior did not manifest during regular backup command because `gpbackup` creates those directories before calling the plugin.
