### PR TITLE
Remove debug configfiguration

### DIFF
--- a/gpbackup_s3_plugin.go
+++ b/gpbackup_s3_plugin.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup-s3-plugin/s3plugin"
 	"github.com/urfave/cli"
 )
 
 func main() {
+	gplog.InitializeLogging("gpbackup_s3_plugin", "")
 	app := cli.NewApp()
 	cli.VersionFlag = cli.BoolFlag{
 		Name:  "version",
@@ -96,8 +98,9 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err.Error())
+	err := app.Run(os.Args)
+	if err != nil {
+		gplog.Error(err.Error())
 		os.Exit(1)
 	}
 }

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -105,7 +105,6 @@ func readConfigAndStartSession(c *cli.Context, operation string) (*PluginConfig,
 	}
 	disableSSL := !ShouldEnableEncryption(config)
 
-	ShouldEnableDebug(config, operation)
 	awsConfig := aws.NewConfig().
 		WithRegion(config.Options["region"]).
 		WithEndpoint(config.Options["endpoint"]).
@@ -125,19 +124,6 @@ func readConfigAndStartSession(c *cli.Context, operation string) (*PluginConfig,
 		return nil, nil, err
 	}
 	return config, sess, nil
-}
-
-func ShouldEnableDebug(config *PluginConfig, operation string) {
-	gplog.InitializeLogging(strings.ToLower(operation), "")
-	verbosity := gplog.LOGINFO
-	if strings.EqualFold(config.Options["debug"], "on") {
-		verbosity = gplog.LOGDEBUG
-	}
-	gplog.SetVerbosity(verbosity)
-}
-
-func GetDebug() int {
-	return gplog.GetVerbosity()
 }
 
 func ShouldEnableEncryption(config *PluginConfig) bool {

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup-s3-plugin/s3plugin"
 	"github.com/urfave/cli"
 
@@ -39,36 +38,6 @@ var _ = Describe("s3_plugin tests", func() {
 			newPath := s3plugin.GetS3Path(folder, path)
 			expectedPath := "s3/Dir/backups/20180101/20180101082233/backup_file"
 			Expect(newPath).To(Equal(expectedPath))
-		})
-	})
-	Describe("ShouldEnableDebug", func() {
-		It("returns INFO when no debug in config during gpbackup", func() {
-			s3plugin.ShouldEnableDebug(pluginConfig, s3plugin.Gpbackup)
-			result := s3plugin.GetDebug()
-			Expect(result).To(Equal(gplog.LOGINFO))
-		})
-		It("returns INFO when no debug in config during gprestore", func() {
-			s3plugin.ShouldEnableDebug(pluginConfig, s3plugin.Gprestore)
-			result := s3plugin.GetDebug()
-			Expect(result).To(Equal(gplog.LOGINFO))
-		})
-		It("returns DEBUG when debug set to 'on' in config", func() {
-			pluginConfig.Options["debug"] = "on"
-			s3plugin.ShouldEnableDebug(pluginConfig, s3plugin.Gpbackup)
-			result := s3plugin.GetDebug()
-			Expect(result).To(Equal(gplog.LOGDEBUG))
-		})
-		It("returns INFO when debug set to 'off' in config", func() {
-			pluginConfig.Options["debug"] = "off"
-			s3plugin.ShouldEnableDebug(pluginConfig, s3plugin.Gprestore)
-			result := s3plugin.GetDebug()
-			Expect(result).To(Equal(gplog.LOGINFO))
-		})
-		It("returns INFO when debug set to anything else in config", func() {
-			pluginConfig.Options["debug"] = "random_text"
-			s3plugin.ShouldEnableDebug(pluginConfig, s3plugin.Gpbackup)
-			result := s3plugin.GetDebug()
-			Expect(result).To(Equal(gplog.LOGINFO))
 		})
 	})
 	Describe("ShouldEnableEncryption", func() {


### PR DESCRIPTION
We don't want to give users the ability to change what gets logged. All
debug statements are logged by default. This also changes the logging
location to gpbackup_s3_plugin.

Authored-by: Kevin Yeap <kyeap@pivotal.io>

## Here are some reminders before you submit the pull request, please:
- [x] Run the unit tests with `make test`
- [x] Run the plugin test bench as described [here](https://github.com/greenplum-db/gpbackup/tree/master/plugins)
