### PR TITLE
Adds upload parameters to config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.30.3
+	github.com/go-ini/ini v1.61.0 // indirect
 	github.com/greenplum-db/gp-common-go-libs v1.0.4
+	github.com/inhies/go-bytesize v0.0.0-20200716184324-4fe85e9b81b2
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/urfave/cli v1.22.4

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-ini/ini v1.61.0 h1:+IytwU4FcXqB+i5Vqiu/Ybf/Jdin9Pwzdxs5lmuT10o=
+github.com/go-ini/ini v1.61.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -26,6 +28,8 @@ github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+d
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/inhies/go-bytesize v0.0.0-20200716184324-4fe85e9b81b2 h1:cdDdMBSC31fswuzvGrd05fGdb5EyCF++DVr8Q1JOhdU=
+github.com/inhies/go-bytesize v0.0.0-20200716184324-4fe85e9b81b2/go.mod h1:KrtyD5PFj++GKkFS/7/RRrfnRhAMGQwy75GLCHWrCNs=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 h1:vr3AYkKovP8uR8AvSGGUK1IDqRa5lAAvEkZG1LKaCRc=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.1.0+incompatible h1:G6xyq9OLi10XNimlx3LFe3e+zkYhbYND9nitiMrJx48=
@@ -44,6 +48,7 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -25,6 +25,7 @@ var Version string
 const apiVersion = "0.4.0"
 const Mebibyte = 1024 * 1024
 const Concurrency = 6
+const UploadChunkSize = int64(Mebibyte) * 10 // default 10MB
 
 type Scope string
 

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -28,6 +28,8 @@ var _ = Describe("s3_plugin tests", func() {
 				"folder":                "folder_name",
 				"region":                "region_name",
 				"endpoint":              "endpoint_name",
+				"upload_concurrency":    "5",
+				"upload_chunk_size":     "7MB",
 			},
 		}
 	})
@@ -114,6 +116,29 @@ var _ = Describe("s3_plugin tests", func() {
 			delete(pluginConfig.Options, "folder")
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(HaveOccurred())
+		})
+	})
+	Describe("Optional config params", func() {
+		It("correctly parses upload params from config", func() {
+			chunkSize, err := s3plugin.GetUploadChunkSize(pluginConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chunkSize).To(Equal(int64(7 * 1024 * 1024)))
+
+			concurrency, err := s3plugin.GetUploadConcurrency(pluginConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(concurrency).To(Equal(5))
+		})
+		It("uses default values if upload params are not specified", func() {
+			delete(pluginConfig.Options, "upload_chunk_size")
+			delete(pluginConfig.Options, "upload_concurrency")
+
+			chunkSize, err := s3plugin.GetUploadChunkSize(pluginConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chunkSize).To(Equal(int64(10 * 1024 * 1024)))
+
+			concurrency, err := s3plugin.GetUploadConcurrency(pluginConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(concurrency).To(Equal(6))
 		})
 	})
 	Describe("Delete", func() {


### PR DESCRIPTION
 - upload_concurrency - int value to configure
   concurrent upload of multi part file. Should
   be less then max_concurrent_requests. Default
   value is 6.
 - upload_chunk_size - bytesize format ("5B", "10KB", "1MB" etc)
   to specify chunk size when upload multi part file.
   Should be more then 5MB to avoid "part size must be at least
   5242880 bytes" error and not less then filesize/10000 to avoid
   "exceeded total allowed configured MaxUploadParts" error.
   Default value is 10Mb.

Authored-by: Kate Dontsova <edontsova@pivotal.io>

## Here are some reminders before you submit the pull request, please:
- [] Run the unit tests with `make test`
- [] Run the plugin test bench as described [here](https://github.com/greenplum-db/gpbackup/tree/master/plugins)
- [] Describe in the PR if any [documentation](https://gpdb.docs.pivotal.io/latest/admin_guide/managing/backup-s3-plugin.html) changes are needed.
