### PR TITLE
Added support to accept http_proxy for s3 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ options:
   bucket: <s3-bucket>
   folder: <s3-location>
   encryption: [on|off]
+  http_proxy: <http-proxy>
  ```
 
 **executablepath:**
@@ -63,6 +64,10 @@ The S3 location for backups. During a backup operation, the plugin creates the S
 **encryption:**
 
 Enable or disable SSL encryption to connect to S3. Valid values are on and off. On by default.
+
+**http_proxy:**
+
+Your http proxy url
 
 ## Example
 This is an example S3 storage plugin configuration file that is used in the next gpbackup example command. The name of the file is s3-test-config.yaml.

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -117,6 +119,17 @@ func readConfigAndStartSession(c *cli.Context, operation string) (*PluginConfig,
 			credentials.NewStaticCredentials(
 				config.Options["aws_access_key_id"],
 				config.Options["aws_secret_access_key"], ""))
+	}
+
+	if config.Options["http_proxy"] != "" {
+		httpclient := &http.Client{
+			Transport: &http.Transport{
+				Proxy: func(*http.Request) (*url.URL, error) {
+					return url.Parse(config.Options["http_proxy"])
+				},
+			},
+		}
+		awsConfig.WithHTTPClient(httpclient)
 	}
 
 	sess, err := session.NewSession(awsConfig)


### PR DESCRIPTION
Exposed a new configuration property for s3 plugin to support configuring proxy.
`http_proxy` which should contain the proxy url of the form `http://username:password@proxy.example.com:1234`

Use `http.Client` as a means to set the proxy address.