### PR TITLE
Adds upload parameters to config

### DIFF
--- a/s3plugin/backup.go
+++ b/s3plugin/backup.go
@@ -227,7 +227,7 @@ func uploadFile(sess *session.Session, config *PluginConfig, bucket string, file
 
 func GetUploadChunkSize(config *PluginConfig) (int64, error) {
 	uploadChunkSize := UploadChunkSize
-	if sizeFromConfig, ok := config.Options["upload_chunk_size"]; ok {
+	if sizeFromConfig, ok := config.Options["backup_multipart_chunksize"]; ok {
 		size, err := bytesize.Parse(sizeFromConfig)
 		if err != nil {
 			return 0, err
@@ -239,7 +239,7 @@ func GetUploadChunkSize(config *PluginConfig) (int64, error) {
 
 func GetUploadConcurrency(config *PluginConfig) (int, error) {
 	uploadConcurrency := Concurrency
-	if val, ok := config.Options["upload_concurrency"]; ok {
+	if val, ok := config.Options["backup_max_concurrent_requests"]; ok {
 		r, err := strconv.Atoi(val)
 		if err != nil {
 			return 0, err

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -22,14 +22,14 @@ var _ = Describe("s3_plugin tests", func() {
 		pluginConfig = &s3plugin.PluginConfig{
 			ExecutablePath: "/tmp/location",
 			Options: map[string]string{
-				"aws_access_key_id":     "12345",
-				"aws_secret_access_key": "6789",
-				"bucket":                "bucket_name",
-				"folder":                "folder_name",
-				"region":                "region_name",
-				"endpoint":              "endpoint_name",
-				"upload_concurrency":    "5",
-				"upload_chunk_size":     "7MB",
+				"aws_access_key_id":              "12345",
+				"aws_secret_access_key":          "6789",
+				"bucket":                         "bucket_name",
+				"folder":                         "folder_name",
+				"region":                         "region_name",
+				"endpoint":                       "endpoint_name",
+				"backup_max_concurrent_requests": "5",
+				"backup_multipart_chunksize":     "7MB",
 			},
 		}
 	})
@@ -129,8 +129,8 @@ var _ = Describe("s3_plugin tests", func() {
 			Expect(concurrency).To(Equal(5))
 		})
 		It("uses default values if upload params are not specified", func() {
-			delete(pluginConfig.Options, "upload_chunk_size")
-			delete(pluginConfig.Options, "upload_concurrency")
+			delete(pluginConfig.Options, "backup_multipart_chunksize")
+			delete(pluginConfig.Options, "backup_max_concurrent_requests")
 
 			chunkSize, err := s3plugin.GetUploadChunkSize(pluginConfig)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
 - backup_max_concurrent_requests - int value to configure
   concurrent upload of multi part file. Should
   be less then max_concurrent_requests. Default
   value is 6.
 - backup_multipart_chunksize - bytesize format ("5B", "10KB", "1MB" etc)
   to specify chunk size when upload multi part file.
   Should be more then 5MB to avoid "part size must be at least
   5242880 bytes" error and not less then filesize/10000 to avoid
   "exceeded total allowed configured MaxUploadParts" error.
   Default value is 10Mb.

Authored-by: Kate Dontsova <edontsova@pivotal.io>

## Here are some reminders before you submit the pull request, please:
- [] Run the unit tests with `make test`
- [] Run the plugin test bench as described [here](https://github.com/greenplum-db/gpbackup/tree/master/plugins)
- [] Describe in the PR if any [documentation](https://gpdb.docs.pivotal.io/latest/admin_guide/managing/backup-s3-plugin.html) changes are needed.
