### PR TITLE
Support connection to Amazon S3 over IPv6

### DIFF
--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -113,7 +113,8 @@ func readConfigAndStartSession(c *cli.Context, operation string) (*PluginConfig,
 		WithRegion(config.Options["region"]).
 		WithEndpoint(config.Options["endpoint"]).
 		WithS3ForcePathStyle(true).
-		WithDisableSSL(disableSSL)
+		WithDisableSSL(disableSSL).
+		WithUseDualStack(true)
 
 	// Will use default credential chain if none provided
 	if config.Options["aws_access_key_id"] != "" {


### PR DESCRIPTION
Connect to Amazon S3 using dual-stack endpoints. Amazon S3 dual-stack
endpoints support requests to S3 buckets over IPv6 and IPv4.  When you
make a request to a dual-stack endpoint, the bucket URL resolves to an
IPv6 or an IPv4 address.