### PR TITLE
Updated upload/download default chunk size and restore data changes

### DIFF
--- a/s3plugin/backup.go
+++ b/s3plugin/backup.go
@@ -213,6 +213,8 @@ func uploadFile(sess *session.Session, config *PluginConfig, bucket string, file
 		u.PartSize = uploadChunkSize
 		u.Concurrency = uploadConcurrency
 	})
+	gplog.Debug("Uploading file %s with chunksize %d and concurrency %d",
+		filepath.Base(fileKey), uploader.PartSize, uploader.Concurrency)
 	_, err = uploader.Upload(&s3manager.UploadInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(fileKey),

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -27,8 +27,8 @@ var Version string
 const apiVersion = "0.4.0"
 const Mebibyte = 1024 * 1024
 const Concurrency = 6
-const UploadChunkSize = int64(Mebibyte) * 10 // default 10MB
-const DownloadChunkSize = int64(Mebibyte) * 10 // default 10MB
+const UploadChunkSize = int64(Mebibyte) * 500 // default 500MB
+const DownloadChunkSize = int64(Mebibyte) * 500 // default 500MB
 
 type Scope string
 


### PR DESCRIPTION
Increased the default upload and download chunk size to 500MB.

Modified restore_data behavior to make sure we always conform with chunk
size and concurrency. We will have as many download workers as the
configured concurrency value and similarly the buffer size that each
worker downloads will be based on the configured chunk size.
Each individual worker will implicitly set the s3 manager's downloader
chunksize as well to the same value and concurrency to 1 as each worker
handles only one chunk at a time.

Added additional debug logging messages.

## Here are some reminders before you submit the pull request, please:
- [] Run the unit tests with `make test`
- [] Run the plugin test bench as described [here](https://github.com/greenplum-db/gpbackup/tree/master/plugins)
- [] Describe in the PR if any [documentation](https://gpdb.docs.pivotal.io/latest/admin_guide/managing/backup-s3-plugin.html) changes are needed.
