### PR TITLE
Do not allow unknown plugin configurations

### DIFF
--- a/s3plugin/restore.go
+++ b/s3plugin/restore.go
@@ -27,7 +27,7 @@ func SetupPluginForRestore(c *cli.Context) error {
 }
 
 func RestoreFile(c *cli.Context) error {
-	config, sess, err := readConfigAndStartSession(c, Gprestore)
+	config, sess, err := readConfigAndStartSession(c)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func RestoreFile(c *cli.Context) error {
 func RestoreDirectory(c *cli.Context) error {
 	start := time.Now()
 	totalBytes := int64(0)
-	config, sess, err := readConfigAndStartSession(c, Gprestore)
+	config, sess, err := readConfigAndStartSession(c)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func RestoreDirectoryParallel(c *cli.Context) error {
 	start := time.Now()
 	totalBytes := int64(0)
 	parallel := 5
-	config, sess, err := readConfigAndStartSession(c, Gprestore)
+	config, sess, err := readConfigAndStartSession(c)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func RestoreDirectoryParallel(c *cli.Context) error {
 }
 
 func RestoreData(c *cli.Context) error {
-	config, sess, err := readConfigAndStartSession(c, Gprestore)
+	config, sess, err := readConfigAndStartSession(c)
 	if err != nil {
 		return err
 	}

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -40,11 +40,6 @@ const (
 	Segment     Scope = "segment"
 )
 
-const (
-	Gpbackup  string = "Gpbackup"
-	Gprestore string = "Gprestore"
-)
-
 type PluginConfig struct {
 	ExecutablePath string        `yaml:"executablepath"`
 	Options        PluginOptions `yaml:"options"`
@@ -174,7 +169,7 @@ func InitializeAndValidateConfig(config *PluginConfig) error {
 	return nil
 }
 
-func readConfigAndStartSession(c *cli.Context, operation string) (*PluginConfig, *session.Session, error) {
+func readConfigAndStartSession(c *cli.Context) (*PluginConfig, *session.Session, error) {
 	configPath := c.Args().Get(0)
 	config, err := readAndValidatePluginConfig(configPath)
 	if err != nil {
@@ -282,7 +277,7 @@ func DeleteBackup(c *cli.Context) error {
 	// note that "backups" is a directory is a fact of how we save, choosing
 	// to use the 3 parent directories of the source file. That becomes:
 	// <s3folder>/backups/<date>/<timestamp>
-	config, sess, err := readConfigAndStartSession(c, Gpbackup)
+	config, sess, err := readConfigAndStartSession(c)
 	if err != nil {
 		return err
 	}

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -18,22 +18,24 @@ func TestCluster(t *testing.T) {
 
 var _ = Describe("s3_plugin tests", func() {
 	var pluginConfig *s3plugin.PluginConfig
+	var opts *s3plugin.PluginOptions
 	BeforeEach(func() {
 		pluginConfig = &s3plugin.PluginConfig{
 			ExecutablePath: "/tmp/location",
-			Options: map[string]string{
-				"aws_access_key_id":              "12345",
-				"aws_secret_access_key":          "6789",
-				"bucket":                         "bucket_name",
-				"folder":                         "folder_name",
-				"region":                         "region_name",
-				"endpoint":                       "endpoint_name",
-				"backup_max_concurrent_requests": "5",
-				"backup_multipart_chunksize":     "7MB",
-				"restore_max_concurrent_requests": "5",
-				"restore_multipart_chunksize":     "7MB",
+			Options: s3plugin.PluginOptions{
+				AwsAccessKeyId:               "12345",
+				AwsSecretAccessKey:           "6789",
+				BackupMaxConcurrentRequests:  "5",
+				BackupMultipartChunksize:     "7MB",
+				Bucket:                       "bucket_name",
+				Endpoint:                     "endpoint_name",
+				Folder:                       "folder_name",
+				Region:                       "region_name",
+				RestoreMaxConcurrentRequests: "5",
+				RestoreMultipartChunksize:    "7MB",
 			},
 		}
+		opts = &pluginConfig.Options
 	})
 	Describe("GetS3Path", func() {
 		It("it combines the folder directory with a path that results from removing all but the last 3 directories of the file path parameter", func() {
@@ -46,23 +48,19 @@ var _ = Describe("s3_plugin tests", func() {
 	})
 	Describe("ShouldEnableEncryption", func() {
 		It("returns true when no encryption in config", func() {
-			delete(pluginConfig.Options, "encryption")
-			result := s3plugin.ShouldEnableEncryption(pluginConfig)
+			result := s3plugin.ShouldEnableEncryption("")
 			Expect(result).To(BeTrue())
 		})
 		It("returns true when encryption set to 'on' in config", func() {
-			pluginConfig.Options["encryption"] = "on"
-			result := s3plugin.ShouldEnableEncryption(pluginConfig)
+			result := s3plugin.ShouldEnableEncryption("on")
 			Expect(result).To(BeTrue())
 		})
 		It("returns false when encryption set to 'off' in config", func() {
-			pluginConfig.Options["encryption"] = "off"
-			result := s3plugin.ShouldEnableEncryption(pluginConfig)
+			result := s3plugin.ShouldEnableEncryption("off")
 			Expect(result).To(BeFalse())
 		})
 		It("returns true when encryption set to anything else in config", func() {
-			pluginConfig.Options["encryption"] = "random_text"
-			result := s3plugin.ShouldEnableEncryption(pluginConfig)
+			result := s3plugin.ShouldEnableEncryption("random_test")
 			Expect(result).To(BeTrue())
 		})
 	})
@@ -72,50 +70,50 @@ var _ = Describe("s3_plugin tests", func() {
 			Expect(err).To(BeNil())
 		})
 		It("succeeds when all fields except endpoint filled in config", func() {
-			delete(pluginConfig.Options, "endpoint")
+			opts.Endpoint = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(BeNil())
 		})
 		It("succeeds when all fields except region filled in config", func() {
-			delete(pluginConfig.Options, "region")
+			opts.Region = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(BeNil())
 		})
 		It("succeeds when all fields except aws_access_key_id and aws_secret_access_key in config", func() {
-			delete(pluginConfig.Options, "aws_access_key_id")
-			delete(pluginConfig.Options, "aws_secret_access_key")
+			opts.AwsAccessKeyId = ""
+			opts.AwsSecretAccessKey = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(BeNil())
 		})
 		It("sets region to unused when endpoint is used instead of region", func() {
-			delete(pluginConfig.Options, "region")
+			opts.Region = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginConfig.Options["region"]).To(Equal("unused"))
+			Expect(pluginConfig.Options.Region).To(Equal("unused"))
 		})
 		It("returns error when neither region nor endpoint in config", func() {
-			delete(pluginConfig.Options, "region")
-			delete(pluginConfig.Options, "endpoint")
+			opts.Region = ""
+			opts.Endpoint = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(HaveOccurred())
 		})
 		It("returns error when no aws_access_key_id in config", func() {
-			delete(pluginConfig.Options, "aws_access_key_id")
+			opts.AwsAccessKeyId = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(HaveOccurred())
 		})
 		It("returns error when no aws_secret_access_key in config", func() {
-			delete(pluginConfig.Options, "aws_secret_access_key")
+			opts.AwsSecretAccessKey = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(HaveOccurred())
 		})
 		It("returns error when no bucket in config", func() {
-			delete(pluginConfig.Options, "bucket")
+			opts.Bucket = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(HaveOccurred())
 		})
 		It("returns error when no folder in config", func() {
-			delete(pluginConfig.Options, "folder")
+			opts.Folder = ""
 			err := s3plugin.ValidateConfig(pluginConfig)
 			Expect(err).To(HaveOccurred())
 		})
@@ -131,8 +129,8 @@ var _ = Describe("s3_plugin tests", func() {
 			Expect(concurrency).To(Equal(5))
 		})
 		It("uses default values if upload params are not specified", func() {
-			delete(pluginConfig.Options, "backup_multipart_chunksize")
-			delete(pluginConfig.Options, "backup_max_concurrent_requests")
+			opts.BackupMultipartChunksize = ""
+			opts.BackupMaxConcurrentRequests = ""
 
 			chunkSize, err := s3plugin.GetUploadChunkSize(pluginConfig)
 			Expect(err).NotTo(HaveOccurred())
@@ -152,8 +150,8 @@ var _ = Describe("s3_plugin tests", func() {
 			Expect(concurrency).To(Equal(5))
 		})
 		It("uses default values if download params are not specified", func() {
-			delete(pluginConfig.Options, "restore_multipart_chunksize")
-			delete(pluginConfig.Options, "restore_max_concurrent_requests")
+			opts.RestoreMultipartChunksize = ""
+			opts.RestoreMaxConcurrentRequests = ""
 
 			chunkSize, err := s3plugin.GetDownloadChunkSize(pluginConfig)
 			Expect(err).NotTo(HaveOccurred())
@@ -169,13 +167,6 @@ var _ = Describe("s3_plugin tests", func() {
 
 		BeforeEach(func() {
 			flags = flag.NewFlagSet("testing flagset", flag.PanicOnError)
-
-			options := make(map[string]string, 0)
-			options["region"] = "us-west-2"
-			options["aws_access_key_id"] = "myId"
-			options["aws_secret_access_key"] = "secret"
-			options["bucket"] = "myBucket"
-			options["folder"] = "foo/bar"
 		})
 		It("returns error when timestamp is not provided", func() {
 			err := flags.Parse([]string{"myconfigfilepath"})


### PR DESCRIPTION
There have been cases where an option was misspelled resulting in
unexpected behavior. Previously, s3 plugin would ignore unknown yaml
options. Now s3 plugin will error out immediately if it finds any
unknown configurations.