### PR TITLE
Added pgport and backup_plugin_version to plugin options

### DIFF
--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -58,6 +58,8 @@ type PluginOptions struct {
 	Region                       string `yaml:"region"`
 	RestoreMaxConcurrentRequests string `yaml:"restore_max_concurrent_requests"`
 	RestoreMultipartChunksize    string `yaml:"restore_multipart_chunksize"`
+	PgPort                       string `yaml:"pgport"`
+	BackupPluginVersion          string `yaml:"backup_plugin_version"`
 
 	UploadChunkSize     int64
 	UploadConcurrency   int


### PR DESCRIPTION
During backup, segment host specific configuration files are created and
this includes `pgport` and `backup_plugin_version` as additional fields in
the options. Now that plugins can only allow specific set of options,
we've added these 2 fields as well.