### PR TITLE
Fix encryption validation to check for "on" and "off"

### DIFF
--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -104,7 +104,7 @@ func InitializeAndValidateConfig(config *PluginConfig) error {
 		opt.Region = "unused"
 	}
 	if opt.Encryption == "" {
-		opt.Encryption = "yes"
+		opt.Encryption = "on"
 	}
 	opt.UploadChunkSize = DefaultUploadChunkSize
 	opt.UploadConcurrency = DefaultConcurrency
@@ -131,8 +131,8 @@ func InitializeAndValidateConfig(config *PluginConfig) error {
 	if opt.Region == "unused" && opt.Endpoint == "" {
 		errTxt += fmt.Sprintf("region or endpoint must exist in plugin configuration file\n")
 	}
-	if opt.Encryption != "yes" && opt.Encryption != "no" {
-		errTxt += fmt.Sprintf("Invalid encryption configuration. Valid choices are yes or no.\n")
+	if opt.Encryption != "on" && opt.Encryption != "off" {
+		errTxt += fmt.Sprintf("Invalid encryption configuration. Valid choices are on or off.\n")
 	}
 	if opt.BackupMultipartChunksize != "" {
 		chunkSize, err := bytesize.Parse(opt.BackupMultipartChunksize)

--- a/s3plugin/s3plugin_test.go
+++ b/s3plugin/s3plugin_test.go
@@ -72,11 +72,11 @@ var _ = Describe("s3_plugin tests", func() {
 				Expect(err).To(BeNil())
 				Expect(opts.Region).To(Equal("unused"))
 			})
-			It(`sets encryption to default value "yes" if none is specified`, func() {
+			It(`sets encryption to default value "on" if none is specified`, func() {
 				opts.Encryption = ""
 				err := s3plugin.InitializeAndValidateConfig(pluginConfig)
 				Expect(err).To(BeNil())
-				Expect(opts.Encryption).To(Equal("yes"))
+				Expect(opts.Encryption).To(Equal("on"))
 			})
 			It("sets backup upload chunk size to default if BackupMultipartChunkSize is not specified", func() {
 				opts.BackupMultipartChunksize = ""


### PR DESCRIPTION
This is to fix a regression caused by my commit 7d329a3. In that commit,
the wrong validation for the encryption option was implemented. The
validation was supposed to ensure that the only valid values of "on" or
"off" were specified, however it was incorrectly checking for the values
"yes" and "no". The appriopriate changes to the test and regression have
been made.

s3 plugin reference regression commit:
https://github.com/greenplum-db/gpbackup-s3-plugin/commit/7d329a3


In the docs
https://gpdb.docs.pivotal.io/43310/admin_guide/managing/backup-s3-plugin.html

The encryption description will need to be updated
```
encryption
Optional. Enable or disable use of Secure Sockets Layer (SSL) when 
connecting to an S3 location. Default value is on, use connections that 
are secured with SSL. Set this option to off to connect to an S3 
compatible service that is not configured to use SSL.
Any value other than off is treated as on.
```
The line `Any value other than off is treated as on.` will no longer be true.

