### PR TITLE
Alter path for endpoint configs

### DIFF
--- a/s3plugin/backup.go
+++ b/s3plugin/backup.go
@@ -199,6 +199,10 @@ func uploadFile(sess *session.Session, config *PluginConfig, fileKey string,
 	uploadChunkSize := config.Options.UploadChunkSize
 	uploadConcurrency := config.Options.UploadConcurrency
 
+	if config.Options.Endpoint != "" {
+		sess.Handlers.Build.PushFront(removeBucketFromPath)
+	}
+
 	uploader := s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
 		u.PartSize = uploadChunkSize
 		u.Concurrency = uploadConcurrency

--- a/s3plugin/restore.go
+++ b/s3plugin/restore.go
@@ -222,6 +222,10 @@ func downloadFile(sess *session.Session, config *PluginConfig, bucket string, fi
 	file *os.File) (int64, time.Duration, error) {
 
 	start := time.Now()
+
+	if config.Options.Endpoint != "" {
+		sess.Handlers.Build.PushFront(removeBucketFromPath)
+	}
 	downloader := s3manager.NewDownloader(sess, func(u *s3manager.Downloader) {
 		u.PartSize = config.Options.DownloadChunkSize
 	})

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -426,3 +426,14 @@ func IsValidTimestamp(timestamp string) bool {
 	timestampFormat := regexp.MustCompile(`^([0-9]{14})$`)
 	return timestampFormat.MatchString(timestamp)
 }
+
+// The AWS SDK automatically prepends "/BucketName/" to any request's path, which breaks placement
+// of all objects when doing backups or restores with an Endpoint URL that already directs requests
+// to the correct bucket. To circumvent this, we manually remove the initial Bucket reference from
+// the path in this case.
+func removeBucketFromPath(req *request.Request) {
+	if strings.HasPrefix(req.Operation.HTTPPath, "/{Bucket}") {
+		req.Operation.HTTPPath = req.Operation.HTTPPath[9:]
+		req.HTTPRequest.URL.Path = req.HTTPRequest.URL.Path[9:]
+	}
+}


### PR DESCRIPTION
In the case of using an endpoint directly, instead of relying on AWS to resolve it, the bucket name gets duplicated in the HTTP path, which means that all of the backups/restores have an extra "root" folder of the bucket name. This breaks things like gpbackup_manager, as well as contravening user expectations.

To solve this, we manually edit the path when uploading or downloading a file with a config that contains a populated Endpoint field.