### PR TITLE
Only remove bucket name if not an IP

### DIFF
--- a/s3plugin/backup.go
+++ b/s3plugin/backup.go
@@ -199,10 +199,6 @@ func uploadFile(sess *session.Session, config *PluginConfig, fileKey string,
 	uploadChunkSize := config.Options.UploadChunkSize
 	uploadConcurrency := config.Options.UploadConcurrency
 
-	if config.Options.Endpoint != "" {
-		sess.Handlers.Build.PushFront(removeBucketFromPath)
-	}
-
 	uploader := s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
 		u.PartSize = uploadChunkSize
 		u.Concurrency = uploadConcurrency

--- a/s3plugin/restore.go
+++ b/s3plugin/restore.go
@@ -223,9 +223,6 @@ func downloadFile(sess *session.Session, config *PluginConfig, bucket string, fi
 
 	start := time.Now()
 
-	if config.Options.Endpoint != "" {
-		sess.Handlers.Build.PushFront(removeBucketFromPath)
-	}
 	downloader := s3manager.NewDownloader(sess, func(u *s3manager.Downloader) {
 		u.PartSize = config.Options.DownloadChunkSize
 	})


### PR DESCRIPTION
AWS SDK only duplicates the bucket name if fed hostname for an endpoint. So add a check whether it's an IP address and do not remove bucketname from path if it is.