### PR TITLE
Fix `NoSuchBucket` using reverts

### DIFF
--- a/s3plugin/backup.go
+++ b/s3plugin/backup.go
@@ -199,10 +199,6 @@ func uploadFile(sess *session.Session, config *PluginConfig, fileKey string,
 	uploadChunkSize := config.Options.UploadChunkSize
 	uploadConcurrency := config.Options.UploadConcurrency
 
-	if config.Options.Endpoint != "" {
-		sess.Handlers.Build.PushFront(removeBucketFromPath)
-	}
-
 	uploader := s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
 		u.PartSize = uploadChunkSize
 		u.Concurrency = uploadConcurrency

--- a/s3plugin/backup.go
+++ b/s3plugin/backup.go
@@ -199,6 +199,10 @@ func uploadFile(sess *session.Session, config *PluginConfig, fileKey string,
 	uploadChunkSize := config.Options.UploadChunkSize
 	uploadConcurrency := config.Options.UploadConcurrency
 
+	if config.Options.Endpoint != "" {
+		sess.Handlers.Build.PushFront(removeBucketFromPath)
+	}
+
 	uploader := s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
 		u.PartSize = uploadChunkSize
 		u.Concurrency = uploadConcurrency

--- a/s3plugin/restore.go
+++ b/s3plugin/restore.go
@@ -222,10 +222,6 @@ func downloadFile(sess *session.Session, config *PluginConfig, bucket string, fi
 	file *os.File) (int64, time.Duration, error) {
 
 	start := time.Now()
-
-	if config.Options.Endpoint != "" {
-		sess.Handlers.Build.PushFront(removeBucketFromPath)
-	}
 	downloader := s3manager.NewDownloader(sess, func(u *s3manager.Downloader) {
 		u.PartSize = config.Options.DownloadChunkSize
 	})

--- a/s3plugin/restore.go
+++ b/s3plugin/restore.go
@@ -223,6 +223,9 @@ func downloadFile(sess *session.Session, config *PluginConfig, bucket string, fi
 
 	start := time.Now()
 
+	if config.Options.Endpoint != "" {
+		sess.Handlers.Build.PushFront(removeBucketFromPath)
+	}
 	downloader := s3manager.NewDownloader(sess, func(u *s3manager.Downloader) {
 		u.PartSize = config.Options.DownloadChunkSize
 	})

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -426,14 +426,3 @@ func IsValidTimestamp(timestamp string) bool {
 	timestampFormat := regexp.MustCompile(`^([0-9]{14})$`)
 	return timestampFormat.MatchString(timestamp)
 }
-
-// The AWS SDK automatically prepends "/BucketName/" to any request's path, which breaks placement
-// of all objects when doing backups or restores with an Endpoint URL that already directs requests
-// to the correct bucket. To circumvent this, we manually remove the initial Bucket reference from
-// the path in this case.
-func removeBucketFromPath(req *request.Request) {
-	if strings.HasPrefix(req.Operation.HTTPPath, "/{Bucket}") {
-		req.Operation.HTTPPath = req.Operation.HTTPPath[9:]
-		req.HTTPRequest.URL.Path = req.HTTPRequest.URL.Path[9:]
-	}
-}

--- a/s3plugin/s3plugin.go
+++ b/s3plugin/s3plugin.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -256,10 +255,6 @@ func readConfigAndStartSession(c *cli.Context) (*PluginConfig, *session.Session,
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if config.Options.Endpoint != "" && net.ParseIP(config.Options.Endpoint) == nil {
-		sess.Handlers.Build.PushFront(removeBucketFromPath)
-	}
 	return config, sess, nil
 }
 
@@ -435,15 +430,10 @@ func IsValidTimestamp(timestamp string) bool {
 // The AWS SDK automatically prepends "/BucketName/" to any request's path, which breaks placement
 // of all objects when doing backups or restores with an Endpoint URL that already directs requests
 // to the correct bucket. To circumvent this, we manually remove the initial Bucket reference from
-// the path in this case. NOTE: this does not happen in if an IP address is used directly, so we
-// attempt to parse IP addresses and do not invoke this removal if found.
+// the path in this case.
 func removeBucketFromPath(req *request.Request) {
-	req.Operation.HTTPPath = strings.Replace(req.Operation.HTTPPath, "/{Bucket}", "", -1)
-	if !strings.HasPrefix(req.Operation.HTTPPath, "/") {
-		req.Operation.HTTPPath = "/" + req.Operation.HTTPPath
-	}
-	req.HTTPRequest.URL.Path = strings.Replace(req.HTTPRequest.URL.Path, "/{Bucket}", "", -1)
-	if !strings.HasPrefix(req.HTTPRequest.URL.Path, "/") {
-		req.HTTPRequest.URL.Path = "/" + req.HTTPRequest.URL.Path
+	if strings.HasPrefix(req.Operation.HTTPPath, "/{Bucket}") {
+		req.Operation.HTTPPath = req.Operation.HTTPPath[9:]
+		req.HTTPRequest.URL.Path = req.HTTPRequest.URL.Path[9:]
 	}
 }


### PR DESCRIPTION
10a4b72d - Only remove bucket name if not an IP
bce4362  - Alter path for endpoint configs

Commits 10a4b72d and bce4362 will be reverted because they cause a
`NoSuchBucket` error when using an endpoint to access a bucket on s3
compliant object storage such as Minio. These two commits have the
assumption that the bucket is automatically appended to the URI when the
endpoint option is used to access the bucket. This is not true as local
testing with Minio starts to fail. The original issue that caused these
two commits seemed to be an error where the URI built using endpoint by
AWS SDK GO was appending the bucket_name twice. I am unable to reproduce
the original duplicate bucket_name seen previously, and these commits
are causing backups and restore when using endpoints to fail. I am
reverting these two commits.

pipeline: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/fix-no-bucket
